### PR TITLE
Changed port in scripts/restart_slurk_server.sh

### DIFF
--- a/scripts/restart_slurk_server.sh
+++ b/scripts/restart_slurk_server.sh
@@ -7,5 +7,5 @@ sudo docker kill slurky
 sudo docker rm slurky
 
 # start docker container for slurk server
-SLURK_SERVER_ID=$(docker run --name=slurky -p $PORT:5000 -e SECRET_KEY=your-key -d slurk/server)
+export SLURK_SERVER_ID=$(docker run --name=slurky -p 80:5000 -e SECRET_KEY=your-key -d slurk/server)
 sleep 1


### PR DESCRIPTION
I changed the port in `scripts/restart_slurk_server.sh` to 80 (similar to the getting started guide). In my case, to restart the server properly, I must use `source scripts/restart_slurk_server.sh` instead of `sh scripts/restart_slurk_server.sh` to update `SLURK_SERVER_ID`. However, I am not sure whether if this also applies to macOS, which is why I didn't modify the instruction in `docs/slurk_gettingstarted.rst` . 